### PR TITLE
Changed magic number to SCL define

### DIFF
--- a/SHT2x.cpp
+++ b/SHT2x.cpp
@@ -75,7 +75,7 @@ uint16_t SHT2xClass::readMeasurement(SHT2xMeasureType type)
 
      //wait for measurement to complete.
      timeout= millis()+300;
-     while (!digitalRead(18)) {
+     while (!digitalRead(PIN_WIRE_SCL)) {
           if (millis()>timeout) {
                return 0;
           }

--- a/SHT2x.cpp
+++ b/SHT2x.cpp
@@ -52,6 +52,7 @@ uint8_t SHT2xClass::readUserRegister()
 void SHT2xClass::writeUserRegister(uint8_t userRegister)
 {
      Wire.beginTransmission(SHT2xADDR);
+     Wire.write(USER_REG_W);
      Wire.write(userRegister);
      Wire.endTransmission();
 }
@@ -114,5 +115,15 @@ void SHT2xClass::setHeater(uint8_t on)
      } else {
           userRegister=(userRegister&~SHT2x_HEATER_MASK) | SHT2x_HEATER_OFF;
      }
+     writeUserRegister(userRegister);
 }
+
+void SHT2xClass::setResolution(SHT2xResolution resolution)
+{
+    uint8_t userRegister;
+    userRegister=readUserRegister();
+    userRegister=(userRegister&~SHT2x_RES_MASK) | resolution;
+    writeUserRegister(userRegister);
+}
+
 SHT2xClass SHT2x;

--- a/SHT2x.h
+++ b/SHT2x.h
@@ -76,6 +76,7 @@ class SHT2xClass {
 public:
      void softReset();
      void setHeater(uint8_t on);
+     void setResolution(SHT2xResolution resolution);
      float readRH();
      float readT();
 


### PR DESCRIPTION
While trying to debug my code I stumbled upon the 18 as SCL. The correct number should be 19 but I figured that on different boards it could also be any number. So I think it is a save bet to change it to the define from Arduino